### PR TITLE
Use $HOME for building expand path to home directory

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 
 set -e
 
-OSX_BOOTSTRAP=${OSX_BOOTSTRAP:-"~/.osx-bootstrap"}
+OSX_BOOTSTRAP=${OSX_BOOTSTRAP:-"$HOME/.osx-bootstrap"}
 
 if [ ! -d "$OSX_BOOTSTRAP" ]
 then

--- a/bin/setup
+++ b/bin/setup
@@ -26,6 +26,6 @@ modules=(
 
 for module in "${modules[@]}"
 do
-  source "$OSX_BOOTSTRAP/modules/$module.bash"
+  bash "$OSX_BOOTSTRAP/modules/$module.bash"
 done
 

--- a/modules/dotfiles.bash
+++ b/modules/dotfiles.bash
@@ -9,6 +9,6 @@ if [ ! -d ~/.dotfiles ]; then
   git clone https://github.com/fs/dotfiles.git ~/.dotfiles
   (
     cd ~/.dotfiles
-    sh script/bootstrap
+    bash script/setup
   )
 fi

--- a/modules/osx_defaults.bash
+++ b/modules/osx_defaults.bash
@@ -221,6 +221,6 @@ defaults write com.googlecode.iterm2 PromptOnQuit -bool false
 # Kill affected applications                                                  #
 ###############################################################################
 
-for app in "cfprefsd" "Dock" "Finder" "Safari"  "SystemUIServer" "Terminal" "iTerm"; do
+for app in "cfprefsd" "Dock" "Finder" "Safari"  "SystemUIServer" "iTerm"; do
   killall "${app}" > /dev/null 2>&1 || true
 done


### PR DESCRIPTION
- Fix wrong path to `$(pwd)/~/.osx-bootstrap`
- Fix https://github.com/fs/osx-bootstrap/blob/bash-compatable-run/modules/osx_version.bash#L3
- Do not kill Terminal during installation process
- Use `script/setup` from dotfiles instead of `script/bootstrap`  