### PR TITLE
Redirect stdout to cat to emulate non-tty terminal.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script:
   - brew install shellcheck
 
 script:
-  - bin/ci
+  - bin/ci | cat
 
 notifications:
   email: false


### PR DESCRIPTION
We need to suppress progress bar from curl to make travis log smaller.