### PR TITLE
Add logging to /tmp/osx-bootstrap.log

### DIFF
--- a/modules/functions.bash
+++ b/modules/functions.bash
@@ -26,3 +26,7 @@ catch_exit() {
 
 # Catch exit
 trap catch_exit EXIT
+
+# Setup loggin
+exec > >(tee -i /tmp/osx-bootstrap."$(date +%Y-%m-%d-%H-%M-%S)".log)
+exec 2>&1


### PR DESCRIPTION
Redirect output to `/tmp/osx-bootstrap-$(current-date).log`
Related to https://github.com/fs/osx-bootstrap/issues/14