### PR TITLE
Remove rbenv-gem-rehash

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -44,5 +44,4 @@ brew "nvm"
 # Ruby
 brew "rbenv"
 brew "ruby-build"
-brew "rbenv-gem-rehash"
 brew "rbenv-default-gems"


### PR DESCRIPTION
`rbenv-gem-rehash` functionality is built into rbenv core now: https://github.com/rbenv/rbenv/pull/638