### PR TITLE
Do not destroy File Vault key on standby

### DIFF
--- a/vendor/osxlockdown/commands.yaml
+++ b/vendor/osxlockdown/commands.yaml
@@ -156,7 +156,7 @@
     pmset -g | grep DestroyFVKeyOnStandby | grep 1
   fix_command: |
     sudo pmset -a destroyfvkeyonstandby 1
-  enabled: true
+  enabled: false
 
 
 - title: "Enable hibernation mode (no memory power on sleep)"
@@ -164,7 +164,7 @@
     pmset -g | grep hibernatemode | grep 25
   fix_command: |
     sudo pmset -a hibernatemode 25
-  enabled: true
+  enabled: false
 
 
 - title: "Enable Gatekeeper"


### PR DESCRIPTION
That is tricky thing and it depends on type of machine – should be used
differently on desktop and laptops.

Also we need to make sure additional settings applied:

```
$ sudo pmset -a powernap 0
$ sudo pmset -a standby 0
$ sudo pmset -a standbydelay 0
$ sudo pmset -a autopoweroff 0
```

The worst think on laptops – it's very annoying to enter password twice each time you
close laptop.

Reference: https://github.com/drduh/OS-X-Security-and-Privacy-Guide#full-disk-encryption