### PR TITLE
Disable node module while we can't figure out why it fails on Travis

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -10,7 +10,9 @@ modules=(
   projectdir
   brew
   ruby
-  node
+  # disable node module while we can't figure out why it fails on Travis
+  # https://travis-ci.org/fs/osx-bootstrap/builds/161264224
+  # node
   osx_defaults
   osx_security
   sublime_bootstrap


### PR DESCRIPTION
https://travis-ci.org/fs/osx-bootstrap/builds/161264224

```
Set latest Node.js version as global default Node ...
Installation fails.
The command "bin/ci" exited with 3.
Done. Your build exited with 1.
/Users/travis/build.sh: line 109: shell_session_update: command not found
```