### PR TITLE
Close SC1117

### DIFF
--- a/modules/functions.bash
+++ b/modules/functions.bash
@@ -7,11 +7,11 @@ green=$(tput setaf 2)
 color_reset=$(tput sgr0)
 
 error_echo() {
-  printf "\n${red}%s.${color_reset}\n" "$1"
+  printf "\\n${red}%s.${color_reset}\\n" "$1"
 }
 
 info_echo() {
-  printf "\n${green}%s ...${color_reset}\n" "$1"
+  printf "\\n${green}%s ...${color_reset}\\n" "$1"
 }
 
 version() {


### PR DESCRIPTION
Backslash is literal in "\n".
Prefer explicit escaping