### PR TITLE
Added memcached; Services will start after install

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -11,6 +11,7 @@ brew "readline", link: true
 brew "git"
 brew "postgresql"
 brew "redis"
+brew "memcached"
 brew "imagemagick"
 # https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#macos-high-sierra-1013-macos-sierra-1012-el-capitan-1011-and-yosemite-1010
 brew "qt@5.5", link: true

--- a/modules/brew.bash
+++ b/modules/brew.bash
@@ -16,6 +16,12 @@ info_echo "Install Brew formalue"
 brew tap "Homebrew/bundle" 2> /dev/null
 brew bundle --file="$osx_bootstrap/Brewfile"
 
+info_echo "Starting services..."
+
+brew services start postgresql
+brew services start redis
+brew services start memcached
+
 info_echo "Remove outdated versions from the cellar"
 
 brew cleanup


### PR DESCRIPTION
- Added memcached, packages that seem to be often used
- Services like postgresql, redis and memcached will be started and ready to use right after bootstrapping