### PR TITLE
Remove HipChat icon from Dock

### DIFF
--- a/modules/osx_defaults.bash
+++ b/modules/osx_defaults.bash
@@ -108,6 +108,7 @@ defaults write com.apple.dock persistent-apps -array
 for app in \
   System\ Preferences \
   Safari \
+  Slack \
   iTerm \
   Sublime\ Text
 do

--- a/modules/osx_defaults.bash
+++ b/modules/osx_defaults.bash
@@ -108,7 +108,6 @@ defaults write com.apple.dock persistent-apps -array
 for app in \
   System\ Preferences \
   Safari \
-  HipChat \
   iTerm \
   Sublime\ Text
 do


### PR DESCRIPTION
# Summary

Remove HipChat icon from Dock
Issue https://github.com/fs/osx-bootstrap/issues/107

# Test plan
Run `~/.osx-bootstrap/modules/osx_defaults.bash` and make sure that there are no HipChat icon in the Dock
