### PR TITLE
Remove installation rbenv and nvm on special dir

### DIFF
--- a/modules/functions.bash
+++ b/modules/functions.bash
@@ -1,6 +1,6 @@
 export HOMEBREW_CASK_OPTS="--appdir=/Applications"
-export RBENV_ROOT=/usr/local/var/rbenv
-export NVM_DIR=/usr/local/var/nvm
+#export RBENV_ROOT=/usr/local/var/rbenv
+#export NVM_DIR=/usr/local/var/nvm
 
 red=$(tput setaf 1)
 green=$(tput setaf 2)

--- a/modules/node.bash
+++ b/modules/node.bash
@@ -8,6 +8,7 @@ info_echo "Enable NVM alias"
 # https://github.com/creationix/nvm/issues/721
 # https://github.com/travis-ci/travis-ci/issues/3854#issuecomment-99492695
 set +e
+#shellcheck source="$(brew --prefix nvm)/nvm.sh"
 source "$(brew --prefix nvm)/nvm.sh"
 set -e
 


### PR DESCRIPTION
Removed function of install rbenv and nvm managers into special non default directory in order to avoid errors with installation pockets again