### PR TITLE
Remove export Rbenv and NVM to special dir

### DIFF
--- a/modules/functions.bash
+++ b/modules/functions.bash
@@ -1,6 +1,6 @@
 export HOMEBREW_CASK_OPTS="--appdir=/Applications"
-export RBENV_ROOT=/usr/local/var/rbenv
-export NVM_DIR=/usr/local/var/nvm
+#export RBENV_ROOT=/usr/local/var/rbenv
+#export NVM_DIR=/usr/local/var/nvm
 
 red=$(tput setaf 1)
 green=$(tput setaf 2)


### PR DESCRIPTION
Removed the installation of rbenv and nvm in a special directory to avoid errors when reinstalling rbenv or nvm