### PR TITLE
Fix Homebrew warning

### DIFF
--- a/bin/quality
+++ b/bin/quality
@@ -2,4 +2,4 @@
 
 set -e
 
-shellcheck --shell bash --exclude=SC1090,SC2086 modules/* bin/setup
+shellcheck --shell bash --exclude=SC1090,SC2086,SC2016 modules/* bin/setup

--- a/modules/brew.bash
+++ b/modules/brew.bash
@@ -19,4 +19,7 @@ brew bundle install --file="$osx_bootstrap/Brewfile"
 
 info_echo "Remove outdated versions from the cellar"
 
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /$HOME/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
 brew cleanup


### PR DESCRIPTION
After the end of installation Homebrew, he sent that we need complete this commands:
echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /$HOME/.zprofile
eval "$(/opt/homebrew/bin/brew shellenv)" 
and i added this in brew.bash